### PR TITLE
Login endpoint updated

### DIFF
--- a/src/main/java/com/jbetfairng/BetfairClient.java
+++ b/src/main/java/com/jbetfairng/BetfairClient.java
@@ -105,9 +105,11 @@ public class BetfairClient {
     private static HashMap<Exchange, String> identityEndpoints = new HashMap<>();
 
     static {
-        identityEndpoints.put(Exchange.RO, "https://identitysso.betfair.ro/api/certlogin");
-        identityEndpoints.put(Exchange.UK, "https://identitysso.betfair.com/api/certlogin");
-        identityEndpoints.put(Exchange.AUS, "https://identitysso.betfair.com/api/certlogin");
+        identityEndpoints.put(Exchange.RO, "https://identitysso-cert.betfair.ro/api/certlogin");
+        identityEndpoints.put(Exchange.UK, "https://identitysso-cert.betfair.com/api/certlogin");
+        identityEndpoints.put(Exchange.AUS, "https://identitysso-cert.betfair.com/api/certlogin");
+        identityEndpoints.put(Exchange.IT, "https://identitysso-cert.betfair.it/api/certlogin");
+        identityEndpoints.put(Exchange.ES, "https://identitysso-cert.betfair.es/api/certlogin");
     }
 
     public BetfairClient(Exchange exchange, String appKey) {

--- a/src/main/java/com/jbetfairng/enums/Exchange.java
+++ b/src/main/java/com/jbetfairng/enums/Exchange.java
@@ -2,6 +2,8 @@ package com.jbetfairng.enums;
 
 public enum Exchange {
     AUS,
+    ES,
+    IT,
     UK,
     RO
 }


### PR DESCRIPTION
Modified according to **Betfair Developer Program** email received on November 27th, 2018.

> Due to required infrastructure changes the non-interactive (bot) login endpoint has been updated to https://identitysso-cert.betfair.com/api/certlogin
> The new endpoint is now live and also available for the following jurisdictions:
> 
> - identitysso-cert.betfair.it
> - identitysso-cert.betfair.es
> - identitysso-cert.betfair.ro
> 
> The previous endpoint (https://identitysso.betfair.com/api/certlogin) will be retired and no longer available after Thursday 20th December 2018. Any attempts to use the old endpoint after this date with return the CERT_AUTH_REQUIRED error.
> We recommend that you update your code as soon as possible with the new endpoint.
> 
> Existing certificates will continue to work with the new endpoint and don't need to be updated.